### PR TITLE
Feature/sm5703charger

### DIFF
--- a/drivers/battery/sm5703_charger.c
+++ b/drivers/battery/sm5703_charger.c
@@ -202,7 +202,6 @@ static void sm5703_enable_charger_switch(struct sm5703_charger_data *charger,
 	bool prev_charging_status = charger->is_charging;
 	
 	charger->is_charging = onoff ? true : false;
-
 	if (onoff > 0 && (prev_charging_status == false)) {
 		pr_info("%s: turn on charger\n", __func__);
 #ifdef CONFIG_FLED_SM5703

--- a/drivers/battery/sm5703_charger.c
+++ b/drivers/battery/sm5703_charger.c
@@ -1797,6 +1797,13 @@ static int sm5703_charger_probe(struct platform_device *pdev)
 	charger->siop_level = 100;
 	charger->ovp = 0;
 	charger->is_mdock = false;
+
+	ret = gpio_request(charger->pdata->chgen_gpio, "sm5703_nCHGEN");
+	if (ret<0) {
+		pr_err("%s : Request GPIO %d failed : %d\n",
+				__func__, (int)charger->pdata->chgen_gpio,ret);
+	}
+
 	sm5703_chg_init(charger);
 
 	charger->wq = create_workqueue("sm5703chg_workqueue");
@@ -1824,12 +1831,6 @@ static int sm5703_charger_probe(struct platform_device *pdev)
 	if (ret < 0)
 		goto err_reg_irq;
 
-	ret = gpio_request(charger->pdata->chgen_gpio, "sm5703_nCHGEN");
-	if (ret<0) {
-		pr_err("%s : Request GPIO %d failed : %d\n",
-				__func__, (int)charger->pdata->chgen_gpio,ret);
-	}
-
 	sm5703_test_read(charger->sm5703->i2c_client);
 	pr_info("%s:[BATT] SM5703 charger driver loaded OK\n", __func__);
 
@@ -1852,6 +1853,7 @@ err_parse_dt_nomem:
 
 static int sm5703_charger_remove(struct platform_device *pdev)
 {
+	pr_info("%s: SM5703 Charger driver remove\n", __func__);
 	struct sm5703_charger_data *charger =
 		platform_get_drvdata(pdev);
 	unregister_irq(pdev, charger);

--- a/drivers/battery/sm5703_charger.c
+++ b/drivers/battery/sm5703_charger.c
@@ -202,6 +202,7 @@ static void sm5703_enable_charger_switch(struct sm5703_charger_data *charger,
 	bool prev_charging_status = charger->is_charging;
 	
 	charger->is_charging = onoff ? true : false;
+
 	if (onoff > 0 && (prev_charging_status == false)) {
 		pr_info("%s: turn on charger\n", __func__);
 #ifdef CONFIG_FLED_SM5703
@@ -1825,9 +1826,9 @@ static int sm5703_charger_probe(struct platform_device *pdev)
 		goto err_reg_irq;
 
 	ret = gpio_request(charger->pdata->chgen_gpio, "sm5703_nCHGEN");
-	if (ret) {
-		pr_info("%s : Request GPIO %d failed\n",
-				__func__, (int)charger->pdata->chgen_gpio);
+	if (ret<0) {
+		pr_err("%s : Request GPIO %d failed : %d\n",
+				__func__, (int)charger->pdata->chgen_gpio,ret);
 	}
 
 	sm5703_test_read(charger->sm5703->i2c_client);
@@ -1861,6 +1862,7 @@ static int sm5703_charger_remove(struct platform_device *pdev)
 		wake_lock_destroy(&charger->vbuslimit_wake_lock);
 	}
 	mutex_destroy(&charger->io_lock);
+	gpio_free(charger->pdata->chgen_gpio);
 	kfree(charger);
 	return 0;
 }


### PR DESCRIPTION
move the gpio_request  "sm5703_nCHGEN" to BEFORE sm5703_chg_init

this fixes the warning seen below

<4>[    0.244413] [c4] WARNING: at ../../../../../../kernel/samsung/universal5433/drivers/gpio/gpiolib.c:160 gpio_ensure_requested+0x78/0xd8()
<4>[    0.244422] [c4] autorequest GPIO-224
<4>[    0.244430] [c4] Modules linked in:
<4>[    0.244445] [c4] CPU: 4 PID: 1 Comm: swapper/0 Not tainted 3.10.21+ #25
<4>[    0.244454] [c4] Backtrace: 
<4>[    0.244471] [c4] [<c0015a18>] (dump_backtrace+0x0/0x128) from [<c0015c68>] (show_stack+0x18/0x1c)
<4>[    0.244480] [c4]  r6:c0c4d824 r5:000000a0 r4:c0353a78 r3:00000000
<4>[    0.244507] [c4] [<c0015c50>] (show_stack+0x0/0x1c) from [<c09a978c>] (dump_stack+0x24/0x2c)
<4>[    0.244523] [c4] [<c09a9768>] (dump_stack+0x0/0x2c) from [<c0035a04>] (warn_slowpath_fmt+0x68/0x88)
<4>[    0.244536] [c4] [<c003599c>] (warn_slowpath_fmt+0x0/0x88) from [<c0353a78>] (gpio_ensure_requested+0x78/0xd8)
<4>[    0.244545] [c4]  r3:000000e0 r2:c0c4d86c
<4>[    0.244557] [c4]  r6:c11ad848 r5:c0f23068 r4:c11ad84c
<4>[    0.244577] [c4] [<c0353a00>] (gpio_ensure_requested+0x0/0xd8) from [<c0354edc>] (gpiod_direction_output+0x6c/0x360)
<4>[    0.244585] [c4]  r8:c11acdc4 r7:00000001 r6:c0f23068 r5:c0a3ced8 r4:c11ad848
<4>[    0.244585] r3:c034fe24
<4>[    0.244614] [c4] [<c0354e70>] (gpiod_direction_output+0x0/0x360) from [<c0356010>] (gpio_direction_output+0x34/0x58)
<4>[    0.244623] [c4]  r9:00000002 r8:e5ee1a68 r7:c000aad8 r6:c0a3cd48 r5:c0a3ced8
<4>[    0.244623] r4:e5ee1800
<4>[    0.244655] [c4] [<c0355fdc>] (gpio_direction_output+0x0/0x58) from [<c0756cdc>] (sm5703_enable_charger_switch+0xec/0x124)
<4>[    0.244670] [c4] [<c0756bf0>] (sm5703_enable_charger_switch+0x0/0x124) from [<c0757ae0>] (sm5703_charger_probe+0xdcc/0x1048)
<4>[    0.244678] [c4]  r5:00000007 r4:e5ee1800
<4>[    0.244698] [c4] [<c0756d14>] (sm5703_charger_probe+0x0/0x1048) from [<c0431480>] (platform_drv_probe+0x20/0x24)
<4>[    0.244713] [c4] [<c0431460>] (platform_drv_probe+0x0/0x24) from [<c042fd10>] (really_probe+0x7c/0x2c8)
<4>[    0.244726] [c4] [<c042fc94>] (really_probe+0x0/0x2c8) from [<c0430118>] (driver_probe_device+0x34/0x54)
<4>[    0.244735] [c4]  r7:c0430184 r6:e5eb4444 r5:c0f4b828 r4:e5eb4410
<4>[    0.244757] [c4] [<c04300e4>] (driver_probe_device+0x0/0x54) from [<c0430218>] (__driver_attach+0x94/0x98)
<4>[    0.244765] [c4]  r5:c0f4b828 r4:e5eb4410
<4>[    0.244783] [c4] [<c0430184>] (__driver_attach+0x0/0x98) from [<c042df8c>] (bus_for_each_dev+0x74/0xa8)
<4>[    0.244791] [c4]  r6:c0f4b828 r5:e69bde60 r4:00000000 r3:00000001
<4>[    0.244812] [c4] [<c042df18>] (bus_for_each_dev+0x0/0xa8) from [<c042f960>] (driver_attach+0x24/0x2c)
<4>[    0.244821] [c4]  r7:00000000 r6:c0f3ac80 r5:c0f4b828 r4:e604ae80
<4>[    0.244842] [c4] [<c042f93c>] (driver_attach+0x0/0x2c) from [<c042f4b0>] (bus_add_driver+0x1dc/0x290)
<4>[    0.244856] [c4] [<c042f2d4>] (bus_add_driver+0x0/0x290) from [<c04308fc>] (driver_register+0x80/0x150)
<4>[    0.244864] [c4]  r7:c0d6a224 r6:00000004 r5:0000014c r4:c0f4b828
<4>[    0.244887] [c4] [<c043087c>] (driver_register+0x0/0x150) from [<c0431a6c>] (platform_driver_register+0x5c/0x70)
<4>[    0.244895] [c4]  r8:e69bc008 r7:c0d6a224 r6:00000004 r5:0000014c r4:c0dd0460
<4>[    0.244895] r3:00000000
<4>[    0.244928] [c4] [<c0431a10>] (platform_driver_register+0x0/0x70) from [<c0db26b8>] (sm5703_charger_init+0x30/0x40)
<4>[    0.244942] [c4] [<c0db2688>] (sm5703_charger_init+0x0/0x40) from [<c000b040>] (do_one_initcall+0x11c/0x1a0)
<4>[    0.244957] [c4] [<c000af24>] (do_one_initcall+0x0/0x1a0) from [<c0d6de4c>] (kernel_init_freeable+0x168/0x254)
<4>[    0.244971] [c4] [<c0d6dce4>] (kernel_init_freeable+0x0/0x254) from [<c099c78c>] (kernel_init+0x10/0x1d8)
<4>[    0.244984] [c4] [<c099c77c>] (kernel_init+0x0/0x1d8) from [<c0011218>] (ret_from_fork+0x14/0x3c)
<4>[    0.244992] [c4]  r5:c099c77c r4:00000000
<4>[    0.245015] [c4] ---[ end trace 4bedb166006344bf ]---