### PR TITLE
revert

### DIFF
--- a/sound/soc/samsung/i2s.c
+++ b/sound/soc/samsung/i2s.c
@@ -1158,10 +1158,11 @@ static int i2s_suspend(struct snd_soc_dai *dai)
 {
 	struct i2s_dai *i2s = to_info(dai);
 
-	i2s->suspend_i2smod = readl(i2s->addr + I2SMOD);
-	i2s->suspend_i2scon = readl(i2s->addr + I2SCON);
-	i2s->suspend_i2spsr = readl(i2s->addr + I2SPSR);
-	
+	if (dai->active) {
+		i2s_cfg_gpio(i2s, "idle");
+		i2s_reg_save(i2s);
+	}
+
 	return 0;
 }
 
@@ -1169,9 +1170,10 @@ static int i2s_resume(struct snd_soc_dai *dai)
 {
 	struct i2s_dai *i2s = to_info(dai);
 
-	writel(i2s->suspend_i2scon, i2s->addr + I2SCON);
-	writel(i2s->suspend_i2smod, i2s->addr + I2SMOD);
-	writel(i2s->suspend_i2spsr, i2s->addr + I2SPSR);
+	if (dai->active) {
+		i2s_reg_restore(i2s);
+		i2s_cfg_gpio(i2s, "default");
+	}
 
 	return 0;
 }


### PR DESCRIPTION
revert change to i2s.c , the change causes kernel panic/crash when pm suspend
Change-Id: I2e9b88c906db4313da65458d879a8c1c8d06d516