### PR TITLE
change to mif_debug from pr_info

### DIFF
--- a/drivers/misc/modem_v1/modem_utils.c
+++ b/drivers/misc/modem_v1/modem_utils.c
@@ -324,7 +324,7 @@ inline void log_ipc_pkt(enum ipc_layer layer, u8 ch, struct sk_buff *skb)
 print_log:
 	buflen = dump_skb(str, SZ_16, skb);
 
-	pr_info("%s: %s(%d): %s\n", MIF_TAG, layer_str(layer), buflen, str);
+	mif_debug("%s: %s(%d): %s\n", MIF_TAG, layer_str(layer), buflen, str);
 
 #ifndef CONFIG_SAMSUNG_PRODUCT_SHIP
 trace_log:


### PR DESCRIPTION
Change-Id: I062729fff943f507621785493dad985ba6fae148
use mif_debug instead of pr_info as the log message is not particularly useful