### PR TITLE
use pr_debug to stop spam dmesg

### DIFF
--- a/drivers/bluetooth/bcm4339.c
+++ b/drivers/bluetooth/bcm4339.c
@@ -188,7 +188,7 @@ static void update_host_wake_locked(int host_wake)
 		 * The chipset deasserts the hostwake lock, when there is no
 		 * more data to send.
 		 */
-		pr_info("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
+		pr_debug("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
 		wake_lock_timeout(&bt_lpm.host_wake_lock, HZ/2);
 	}
 }

--- a/drivers/bluetooth/bcm43455.c
+++ b/drivers/bluetooth/bcm43455.c
@@ -190,7 +190,7 @@ static void update_host_wake_locked(int host_wake)
 		 * The chipset deasserts the hostwake lock, when there is no
 		 * more data to send.
 		 */
-		pr_info("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
+		pr_debug("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
 		wake_lock_timeout(&bt_lpm.host_wake_lock, HZ);
 	}
 }

--- a/drivers/bluetooth/bcm43457.c
+++ b/drivers/bluetooth/bcm43457.c
@@ -172,7 +172,7 @@ static void update_host_wake_locked(int host_wake)
 		 * The chipset deasserts the hostwake lock, when there is no
 		 * more data to send.
 		 */
-		pr_info("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
+		pr_debug("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
 		wake_lock_timeout(&bt_lpm.host_wake_lock, HZ/2);
 	}
 }

--- a/drivers/bluetooth/bcm4354.c
+++ b/drivers/bluetooth/bcm4354.c
@@ -188,7 +188,7 @@ static void update_host_wake_locked(int host_wake)
 		 * The chipset deasserts the hostwake lock, when there is no
 		 * more data to send.
 		 */
-		pr_info("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
+		pr_debug("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
 		wake_lock_timeout(&bt_lpm.host_wake_lock, HZ/2);
 	}
 }

--- a/drivers/bluetooth/bcm4358.c
+++ b/drivers/bluetooth/bcm4358.c
@@ -188,7 +188,7 @@ static void update_host_wake_locked(int host_wake)
 		 * The chipset deasserts the hostwake lock, when there is no
 		 * more data to send.
 		 */
-		pr_info("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
+		pr_debug("[BT] update_host_wake_locked host_wake is deasserted. release wakelock in 1s\n");
 		wake_lock_timeout(&bt_lpm.host_wake_lock, HZ/2);
 	}
 }


### PR DESCRIPTION
Change-Id: Ia3c25405804b758a590e5141badcab93f1e2c554

use pr_debug instead of pr_info to stop spamming dmesg with messages