### PR TITLE
Feature/revertgadgetargos

### DIFF
--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -46,8 +46,8 @@
 
 int irq_select_affinity_usr(unsigned int irq, struct cpumask *mask);
 
-//static struct notifier_block rndis_notifier;
-//static int gadget_irq = 0;
+static struct notifier_block rndis_notifier;
+static int gadget_irq = 0;
 #endif
 #if defined(CONFIG_USB_SUPER_HIGH_SPEED_SWITCH_CHANGE)
 #define EP0_HS_MPS 64
@@ -1834,26 +1834,26 @@ static int set_cpu_core_from_usb_irq(int enable)
 }
 
 
-// static int rndis_notify_callback(struct notifier_block *this,
-// 				unsigned long event, void *ptr)
-// {
-// 	struct net_device *dev = ptr;
+static int rndis_notify_callback(struct notifier_block *this,
+				unsigned long event, void *ptr)
+{
+	struct net_device *dev = ptr;
 
-// 	if (!net_eq(dev_net(dev), &init_net))
-// 		return NOTIFY_DONE;
+	if (!net_eq(dev_net(dev), &init_net))
+		return NOTIFY_DONE;
 
-// 	if (!strncmp(dev->name, "rndis", 5)) {
-// 		switch (event) {
-// 		case NETDEV_UP:
-// 			set_cpu_core_from_usb_irq(true);
-// 			break;
-// 		case NETDEV_DOWN:
-// 			set_cpu_core_from_usb_irq(false);
-// 			break;
-// 		}
-// 	}
-// 	return NOTIFY_DONE;
-// }
+	if (!strncmp(dev->name, "rndis", 5)) {
+		switch (event) {
+		case NETDEV_UP:
+			set_cpu_core_from_usb_irq(true);
+			break;
+		case NETDEV_DOWN:
+			set_cpu_core_from_usb_irq(false);
+			break;
+		}
+	}
+	return NOTIFY_DONE;
+}
 #endif
 
 static int dwc3_gadget_start(struct usb_gadget *g,

--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -1864,11 +1864,10 @@ static int dwc3_gadget_start(struct usb_gadget *g,
 	unsigned long		flags;
 	int			ret = 0;
 	int			irq;
-	u32			reg;
 
 	irq = platform_get_irq(to_platform_device(dwc->dev), 0);
-	ret = request_threaded_irq(irq, dwc3_interrupt, dwc3_thread_interrupt,
-			IRQF_SHARED | IRQF_ONESHOT, "dwc3", dwc);
+	ret = devm_request_irq(dwc->dev, irq, dwc3_interrupt,
+			IRQF_SHARED, "dwc3", dwc);
 	if (ret) {
 		dev_err(dwc->dev, "failed to request irq #%d --> %d\n",
 				irq, ret);
@@ -1887,69 +1886,30 @@ static int dwc3_gadget_start(struct usb_gadget *g,
 
 	dwc->gadget_driver	= driver;
 
-	reg = dwc3_readl(dwc->regs, DWC3_DCFG);
-	reg &= ~(DWC3_DCFG_SPEED_MASK);
-
-	/**
-	 * WORKAROUND: DWC3 revision < 2.20a have an issue
-	 * which would cause metastability state on Run/Stop
-	 * bit if we try to force the IP to USB2-only mode.
-	 *
-	 * Because of that, we cannot configure the IP to any
-	 * speed other than the SuperSpeed
-	 *
-	 * Refers to:
-	 *
-	 * STAR#9000525659: Clock Domain Crossing on DCTL in
-	 * USB 2.0 Mode
-	 */
-	if (dwc->revision < DWC3_REVISION_220A)
-		reg |= DWC3_DCFG_SUPERSPEED;
-	else
-		reg |= dwc->maximum_speed;
-	dwc3_writel(dwc->regs, DWC3_DCFG, reg);
-
-	dwc->start_config_issued = false;
-
-	/* Start with SuperSpeed Default */
-	dwc3_gadget_ep0_desc.wMaxPacketSize = cpu_to_le16(512);
-
-	dep = dwc->eps[0];
-	ret = __dwc3_gadget_ep_enable(dep, &dwc3_gadget_ep0_desc, NULL, false);
-	if (ret) {
-		dev_err(dwc->dev, "failed to enable %s\n", dep->name);
-		goto err2;
-	}
-
-	dep = dwc->eps[1];
-	ret = __dwc3_gadget_ep_enable(dep, &dwc3_gadget_ep0_desc, NULL, false);
-	if (ret) {
-		dev_err(dwc->dev, "failed to enable %s\n", dep->name);
-		goto err3;
-	}
-
-	/* begin to receive SETUP packets */
-	dwc->ep0state = EP0_SETUP_PHASE;
-	dwc3_ep0_out_start(dwc);
-
-	dwc3_gadget_enable_irq(dwc);
-
 	spin_unlock_irqrestore(&dwc->lock, flags);
 
+#ifdef CONFIG_USBIRQ_BALANCING_LTE_HIGHTP
+	gadget_irq = irq;
+	rndis_notifier.notifier_call = rndis_notify_callback;
+	register_netdevice_notifier(&rndis_notifier);
+#endif
+#ifdef CONFIG_ARGOS
+		if (!zalloc_cpumask_var(&affinity_cpu_mask, GFP_KERNEL))
+			return -ENOMEM;
+		if (!zalloc_cpumask_var(&default_cpu_mask, GFP_KERNEL))
+			return -ENOMEM;
+	
+		cpumask_copy(default_cpu_mask, get_default_cpu_mask());
+		cpumask_or(affinity_cpu_mask, affinity_cpu_mask, cpumask_of(3));
+		argos_irq_affinity_setup_label(irq, "USB", affinity_cpu_mask, default_cpu_mask);
+#endif
+
+
 	return 0;
-
-err3:
-	__dwc3_gadget_ep_disable(dwc->eps[0]);
-
-err2:
-	dwc->gadget_driver = NULL;
 
 err1:
 	spin_unlock_irqrestore(&dwc->lock, flags);
 
-	free_irq(irq, dwc);
-
-err0:
 	free_irq(irq, dwc);
 
 err0:
@@ -1975,6 +1935,9 @@ static int dwc3_gadget_stop(struct usb_gadget *g,
 
 	irq = platform_get_irq(to_platform_device(dwc->dev), 0);
 	free_irq(irq, dwc);
+#ifdef CONFIG_USBIRQ_BALANCING_LTE_HIGHTP
+	unregister_netdevice_notifier(&rndis_notifier);
+#endif
 
 	return 0;
 }

--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -1950,6 +1950,9 @@ err1:
 	free_irq(irq, dwc);
 
 err0:
+	free_irq(irq, dwc);
+
+err0:
 	return ret;
 }
 


### PR DESCRIPTION
revert these commits to gadget.c 

The patches causing multiple kernel reboots and this unhandled fault to be seen in /proc/last_kmsg

<1>[    4.272058] [c4] Unhandled fault: imprecise external abort (0x1406) at 0x00000000
<1>[    4.272068] [c4] pgd = e39a4000
<1>[    4.272076] [c4] [00000000] *pgd=00000000
<0>[    4.272159] [c4] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000007